### PR TITLE
Add basic functionality of leapp report analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,72 @@
-# leapp-report-analyzer
+# Leapp Report Analyzer
+
+Leapp Report Analyzer is a command-line tool for analyzing multiple **[Leapp](https://github.com/oamg/leapp)** reports and grouping systems by severity and entries.
+The tool processes JSON files containing Leapp reports and generates a JSON file and an HTML table displaying the results.
+
+By analyzing Leapp reports and providing organized output, the Leapp Report Analyzer simplifies the process of identifying and addressing potential issues in your systems.
+
+More information about Leapp:
+- [Leapp GitHub repository](https://github.com/oamg/leapp) - report schemas can be found here
+- [Leapp Documentation](https://leapp.readthedocs.io/en/latest/)
+
+## Installation
+
+Download the Python script from this repository or use:
+
+```bash
+curl -OJL https://raw.githubusercontent.com/oamg/leapp-report-analyzer/main/leapp-report-analyzer.py
+```
+
+### Requirements
+
+Script works on both Python2 and Python3, versions:
+
+- Python 2.7
+- Python 3.2+
+
+## Usage
+
+You can use the Leapp Report Analyzer with either individual Leapp report JSON files or a directory containing multiple JSON files.
+The following arguments are required:
+- `-f / --input-files`: One or more Leapp report JSON files to be analyzed (e.g., `-f report1.json report2.json`). Not required if `-d` is used.
+- `-d / --input-directory`: A directory containing Leapp report JSON files to be analyzed (e.g., `-d reports_directory`). Not required if `-f` is used.
+- `-o / --output-json`: The output JSON file to store the grouped data (e.g., `-o output.json`).
+- `-t / --output-html`: The output HTML file to store the tables with grouped data (e.g., `-t output.html`).
+
+For more detailed information, run:
+```bash
+python leapp-report-analyzer.py -h
+```
+
+### Example Usage
+
+Analyze individual Leapp report JSON files:
+
+```bash
+python leapp-report-analyzer.py -f report1.json report2.json -o output.json -t output.html
+```
+
+Analyze a directory containing Leapp report JSON files:
+
+```bash
+python leapp-report-analyzer.py -d reports_directory -o output.json -t output.html
+```
+
+## Severity Levels
+
+The generated report will group entries according to the following severity levels:
+
+- **Inhibitor**: Will inhibit (hard stop) the upgrade process, otherwise the system could become unbootable, inaccessible, or dysfunctional.
+- **High**: Very likely to result in a deteriorated system state.
+- **Medium**: Can impact both the system and applications.
+- **Low**: Should not impact the system but can have an impact on applications.
+- **Info**: Informational with no expected impact to the system or applications.
+
+These severity levels help you understand the potential impact of the issues found in the leapp reports and prioritize your actions accordingly.
+
+## Output
+
+The Leapp Report Analyzer generates two output files:
+
+- `output.json`: A JSON file containing the grouped data organized by severity and entry title. Each severity level has a dictionary with the title of the entry as the key and a list of hostnames as the value.
+- `output.html`: An HTML file containing tables displaying the grouped data. Each severity level has its own table with two columns: Entry Title and Hostnames.

--- a/README.md
+++ b/README.md
@@ -27,11 +27,13 @@ Script works on both Python2 and Python3, versions:
 ## Usage
 
 You can use the Leapp Report Analyzer with either individual Leapp report JSON files or a directory containing multiple JSON files.
-The following arguments are required:
-- `-f / --input-files`: One or more Leapp report JSON files to be analyzed (e.g., `-f report1.json report2.json`). Not required if `-d` is used.
-- `-d / --input-directory`: A directory containing Leapp report JSON files to be analyzed (e.g., `-d reports_directory`). Not required if `-f` is used.
-- `-o / --output-json`: The output JSON file to store the grouped data (e.g., `-o output.json`).
-- `-t / --output-html`: The output HTML file to store the tables with grouped data (e.g., `-t output.html`).
+Using one of the following arguments is required:
+- `-f / --input-files`: One or more Leapp report JSON files to be analyzed (e.g., `-f report1.json report2.json`).
+- `-d / --input-directory`: A directory containing Leapp report JSON files to be analyzed (e.g., `-d reports_directory`).
+
+Output arguments are optional:
+- `-o / --output-json`: The output JSON file to store the grouped data (e.g., `-o output.json`). Default: `leapp_report_analysis.json`
+- `-t / --output-html`: The output HTML file to store the tables with grouped data (e.g., `-t output.html`). Default: `leapp_report_analysis.html`
 
 For more detailed information, run:
 ```bash
@@ -50,6 +52,12 @@ Analyze a directory containing Leapp report JSON files:
 
 ```bash
 python leapp-report-analyzer.py -d reports_directory -o output.json -t output.html
+```
+
+Analyze a directory, use the default output file names:
+
+```bash
+python leapp-report-analyzer.py -d reports_directory
 ```
 
 ## Severity Levels

--- a/leapp-report-analyzer.py
+++ b/leapp-report-analyzer.py
@@ -18,14 +18,6 @@ JSON_OUTPUT_DEFAULT = "leapp_report_analysis.json"
 HTML_OUTPUT_DEFAULT = "leapp_report_analysis.html"
 
 
-def _create_grouped_data_structure():
-    # JSON structure: {severity: [key: {title: str, {hostnames: [], remediations: {}}]}
-    return defaultdict(lambda: defaultdict(lambda: {"title": "", "hostnames": [], "remediations": []}))
-
-
-def escape_html(text):
-    return escape(text, quote=True)
-
 
 def main():
     logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
@@ -87,7 +79,7 @@ def parse_leapp_report(report_file):
     with open(report_file, "r") as f:
         report_data = json.load(f)
 
-    grouped_data = _create_grouped_data_structure()
+    grouped_data = create_grouped_data_structure()
 
     for entry in report_data["entries"]:
         severity = entry["severity"]
@@ -108,9 +100,14 @@ def parse_leapp_report(report_file):
     return grouped_data
 
 
+def create_grouped_data_structure():
+    # JSON structure: {severity: [key: {title: str, {hostnames: [], remediations: {}}]}
+    return defaultdict(lambda: defaultdict(lambda: {"title": "", "hostnames": [], "remediations": []}))
+
+
 def merge_grouped_data(grouped_data_list):
     """Merge grouped data from multiple reports into one."""
-    merged_data = _create_grouped_data_structure()
+    merged_data = create_grouped_data_structure()
 
     for grouped_data in grouped_data_list:
         for severity, entries in grouped_data.items():
@@ -186,6 +183,10 @@ def generate_html_tables(grouped_data):
     return html_tables
 
 
+def escape_html(text):
+    return escape(text, quote=True)
+
+
 def generate_severity_legend_table():
     html_table = "<h3>Severity Levels Legend</h3>\n"
     html_table += "<table {}>\n".format(HTML_TABLE_OPTIONS)
@@ -216,5 +217,5 @@ def write_html_tables_to_file(html_tables, output_file):
         f.write(html_template.format(content=html_tables))
 
 
-if __name__:
+if __name__ == "__main__":
     main()

--- a/leapp-report-analyzer.py
+++ b/leapp-report-analyzer.py
@@ -1,6 +1,7 @@
 import argparse
 import glob
 import json
+import logging
 import os
 import sys
 from collections import OrderedDict, defaultdict
@@ -25,6 +26,8 @@ def escape_html(text):
 
 
 def main():
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
     parser = get_parser()
     args = parser.parse_args()
 
@@ -33,12 +36,20 @@ def main():
     else:
         input_files = args.input_files
 
+    logging.info("Processing %d input files", len(input_files))
+
     grouped_data_list = [parse_leapp_report(input_file) for input_file in input_files]
     merged_grouped_data = merge_grouped_data(grouped_data_list)
     ordered_merged_data = order_grouped_data(merged_grouped_data)
+
+    logging.info("Writing JSON output to %s", args.output_json)
     write_grouped_data_to_json(ordered_merged_data, args.output_json)
+
+    logging.info("Writing HTML output to %s", args.output_html)
     html_tables = generate_html_tables(ordered_merged_data)
     write_html_tables_to_file(html_tables, args.output_html)
+
+    logging.info("Results written to %s and %s", args.output_json, args.output_html)
 
 
 def get_parser():
@@ -63,6 +74,7 @@ def get_parser():
 
 
 def parse_leapp_report(report_file):
+    logging.info("Processing report file: %s", report_file)
     with open(report_file, "r") as f:
         report_data = json.load(f)
 

--- a/leapp-report-analyzer.py
+++ b/leapp-report-analyzer.py
@@ -1,0 +1,135 @@
+import argparse
+import collections
+import json
+import glob
+import os
+import sys
+# Check if Python version is 3.6 or higher (cgi.escape is deprecated/removed for newer versions)
+if sys.version_info.major >= 3 and sys.version_info.minor >= 6:
+    from html import escape
+else:
+    from cgi import escape
+
+SEVERITY_ORDER = ["inhibitor", "high", "medium", "low", "info"]
+
+
+def main():
+    parser = get_parser()
+    args = parser.parse_args()
+
+    if args.input_directory:
+        input_files = glob.glob(os.path.join(args.input_directory, "*.json"))
+    else:
+        input_files = args.input_files
+
+    grouped_data_list = [parse_leapp_report(input_file) for input_file in input_files]
+    merged_grouped_data = merge_grouped_data(grouped_data_list)
+    write_grouped_data_to_json(merged_grouped_data, args.output_json)
+    html_tables = generate_html_tables(merged_grouped_data)
+    write_html_tables_to_file(html_tables, args.output_html)
+
+
+def get_parser():
+    parser = argparse.ArgumentParser(description="Analyze leapp reports and group systems by severity and entries.")
+
+    input_group = parser.add_argument_group("input", "Input options (at least one required)")
+    input_group_exclusive = input_group.add_mutually_exclusive_group(required=True)
+    input_group_exclusive.add_argument(
+        "-f", "--input-files", nargs="+", metavar="INPUT_FILE", help="leapp report JSON files to be analyzed"
+    )
+    input_group_exclusive.add_argument(
+        "-d", "--input-directory", help="Directory containing leapp report JSON files to be analyzed"
+    )
+
+    output_group = parser.add_argument_group("output", "Output options, both required")
+    output_group.add_argument(
+        "-o", "--output-json", required=True, help="Output JSON file to store the grouped data"
+    )
+    output_group.add_argument(
+        "-t", "--output-html", required=True, help="Output HTML file to store the tables with grouped data"
+    )
+
+    return parser
+
+
+def parse_leapp_report(report_file):
+    with open(report_file, "r") as f:
+        report_data = json.load(f)
+
+    grouped_data = collections.defaultdict(lambda: collections.defaultdict(set))
+    for entry in report_data["entries"]:
+        severity = entry["severity"]
+        entry_flags = entry.get("flags", entry.get("groups", []))
+        if "inhibitor" in entry_flags:
+            severity = "inhibitor"
+        grouped_data[severity][entry["title"]].add(entry["hostname"])
+
+    return grouped_data
+
+
+def merge_grouped_data(grouped_data_list):
+    """Merge grouped data from multiple reports into one. And sort entries and hostnames alphabetically."""
+    merged_data = collections.defaultdict(lambda: collections.defaultdict(set))
+
+    for grouped_data in grouped_data_list:
+        for severity, entries in grouped_data.items():
+            for entry_title, hostnames in entries.items():
+                merged_data[severity][entry_title].update(hostnames)
+
+    ordered_merged_data = collections.OrderedDict()
+    for severity in SEVERITY_ORDER:
+        if severity in merged_data:
+            # Sort entries and hostnames alphabetically
+            ordered_merged_data[severity] = collections.OrderedDict(
+                sorted(
+                    ((entry_title, sorted(list(hostnames))) for entry_title, hostnames in merged_data[severity].items()),
+                    key=lambda x: x[0]
+                )
+            )
+
+    return ordered_merged_data
+
+
+def write_grouped_data_to_json(grouped_data, output_file):
+    with open(output_file, "w") as f:
+        json.dump(grouped_data, f, indent=2)
+
+
+def generate_html_tables(grouped_data):
+    html_tables = ""
+
+    for severity in grouped_data:
+        entries = grouped_data[severity]
+
+        html_table = "<h2>{}</h2>\n".format(severity.capitalize())
+        html_table += "<table border='1' cellpadding='5' cellspacing='0'>\n"
+        html_table += "<tr><th>Entry Title</th><th>Hostnames</th></tr>\n"
+        for entry_title, hostnames in entries.items():
+            escaped_entry_title = escape(entry_title, quote=True)
+            html_table += "<tr><td>{}</td><td>{}</td></tr>\n".format(escaped_entry_title, ", ".join(hostnames))
+        html_table += "</table>"
+
+        html_tables += html_table + "<br>\n"
+
+    return html_tables
+
+
+def write_html_tables_to_file(html_tables, output_file):
+    html_template = """<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Leapp Report Analyzer</title>
+    <style>table, th, td {{border: 1px solid black;}}</style>
+</head>
+<body>
+{content}
+</body>
+</html>
+"""
+    with open(output_file, "w") as f:
+        f.write(html_template.format(content=html_tables))
+
+
+if __name__:
+    main()

--- a/leapp-report-analyzer.py
+++ b/leapp-report-analyzer.py
@@ -14,6 +14,8 @@ else:
 
 SEVERITY_ORDER = ["inhibitor", "high", "medium", "low", "info"]
 HTML_TABLE_OPTIONS = "border='1' cellpadding='5' cellspacing='0'"
+JSON_OUTPUT_DEFAULT = "leapp_report_analysis.json"
+HTML_OUTPUT_DEFAULT = "leapp_report_analysis.html"
 
 
 def _create_grouped_data_structure():
@@ -31,6 +33,8 @@ def main():
     parser = get_parser()
     args = parser.parse_args()
 
+    output_json = args.output_json or JSON_OUTPUT_DEFAULT
+    output_html = args.output_html or HTML_OUTPUT_DEFAULT
     if args.input_directory:
         input_files = glob.glob(os.path.join(args.input_directory, "*.json"))
     else:
@@ -42,14 +46,14 @@ def main():
     merged_grouped_data = merge_grouped_data(grouped_data_list)
     ordered_merged_data = order_grouped_data(merged_grouped_data)
 
-    logging.info("Writing JSON output to %s", args.output_json)
-    write_grouped_data_to_json(ordered_merged_data, args.output_json)
+    logging.info("Writing JSON output to %s", output_json)
+    write_grouped_data_to_json(ordered_merged_data, output_json)
 
-    logging.info("Writing HTML output to %s", args.output_html)
+    logging.info("Writing HTML output to %s", output_html)
     html_tables = generate_html_tables(ordered_merged_data)
-    write_html_tables_to_file(html_tables, args.output_html)
+    write_html_tables_to_file(html_tables, output_html)
 
-    logging.info("Results written to %s and %s", args.output_json, args.output_html)
+    logging.info("Results written to %s and %s", output_json, output_html)
 
 
 def get_parser():
@@ -64,10 +68,15 @@ def get_parser():
         "-d", "--input-directory", help="Directory containing leapp report JSON files to be analyzed"
     )
 
-    output_group = parser.add_argument_group("output", "Output options, both required")
-    output_group.add_argument("-o", "--output-json", required=True, help="Output JSON file to store the grouped data")
-    output_group.add_argument(
-        "-t", "--output-html", required=True, help="Output HTML file to store the tables with grouped data"
+    parser.add_argument(
+        "-o",
+        "--output-json",
+        help="Output JSON file to store the grouped data (default: '{}')".format(JSON_OUTPUT_DEFAULT),
+    )
+    parser.add_argument(
+        "-t",
+        "--output-html",
+        help="Output HTML file to store the tables with grouped data (default: '{}')".format(HTML_OUTPUT_DEFAULT),
     )
 
     return parser


### PR DESCRIPTION
Introduce script to analyze and group multiple leapp report JSON files into a single JSON output and an HTML tables output.

The scripts takes a list of input files, merges their data, and groups the hostnames by severity.

Output is sorted by severity.

Add support for checking the 'groups' field if the 'flags' field is not present in the leapp report entry. So we can parse multiple versions of leapp report schemas.

The script seems to work for both python2.7 and 3+ versions.

Usage: leapp-report-analyzer.py [-h] -o OUTPUT_JSON -t OUTPUT_HTML input_file [input_file ...]
```
leapp-report-analyzer leapp-report1.json leapp-report2.json -o output.json -t output.html
```